### PR TITLE
Set rsyslog_fluentd_host to internal_address by default

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -90,7 +90,7 @@ osism_strategy: linear
 # rsyslog
 
 fluentd_host: "{{ rsyslog_fluentd_host }}"
-rsyslog_fluentd_host: "{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}"
+rsyslog_fluentd_host: "{{ internal_address }}"
 
 ##########################
 # cockpit


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>