### PR TITLE
kolla: set default value when horizon_enable_tls_backend is not set

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -346,7 +346,7 @@ heat_api_cfn_listen_port: "{{ heat_api_cfn_port }}"
 
 horizon_port: "80"
 horizon_tls_port: "443"
-horizon_listen_port: "{{ horizon_tls_port if horizon_enable_tls_backend | bool else horizon_port }}"
+horizon_listen_port: "{{ horizon_tls_port if horizon_enable_tls_backend | default(kolla_enable_tls_backend) | bool else horizon_port }}"
 
 influxdb_http_port: "8086"
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>