### PR TITLE
Remove kolla_image_version

### DIFF
--- a/all/002-images-kolla.yml
+++ b/all/002-images-kolla.yml
@@ -1,6 +1,5 @@
 ---
 docker_namespace: osism
-kolla_image_version: latest
 
 ##############################
 # role: ceilometer


### PR DESCRIPTION
The version of Kolla to be used is not set via the defaults
and leads to problems when creating the inventory if it is
set here.

The active Kolla version is made available to the Inventory
Reconciler via the interface volume from the Kolla Ansible container.

Signed-off-by: Christian Berendt <berendt@osism.tech>