### PR TITLE
kolla: enable grafana by default

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -13,6 +13,7 @@ enable_chrony: "no"
 enable_central_logging: "yes"
 enable_prometheus: "yes"
 enable_redis: "yes"
+enable_grafana: "yes"
 
 # openstack
 


### PR DESCRIPTION
Currently, Grafana is explicitly activated via the
configuration repository. By default it is only
activated if Monasca is activated.

From now on, Grafana is always activated by default
and must be explicitly deactivated in the configuration
repository if required.

Signed-off-by: Christian Berendt <berendt@osism.tech>