### PR TITLE
Disable ModemManager.service

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -174,3 +174,9 @@ security_sshd_allowed_macs: hmac-sha2-256,hmac-sha2-512,hmac-sha1
 # proxy
 
 proxy_proxies: {}
+
+##########################
+# cleanup
+
+cleanup_services_default:
+  - ModemManager.service


### PR DESCRIPTION
The ModemManager.service is activated when using the default
Ubuntu images. It is usually not needed.

Signed-off-by: Christian Berendt <berendt@osism.tech>