### PR TITLE
Fix mariabackup image

### DIFF
--- a/all/002-images-kolla.yml
+++ b/all/002-images-kolla.yml
@@ -211,7 +211,7 @@ mariadb_image: "{{ docker_registry }}/{{ docker_namespace }}/{{ 'mariadb' if ope
 mariadb_tag: "{{ kolla_mariadb_version|default(kolla_image_version) }}"
 mariadb_clustercheck_image: "{{ docker_registry }}/{{ docker_namespace }}/mariadb-clustercheck"
 mariadb_clustercheck_tag: "{{ mariadb_tag }}"
-mariabackup_image: "{{ docker_registry }}/{{ docker_namespace }}/mariabackup"
+mariabackup_image: "{{ mariadb_image }}"
 mariabackup_tag: "{{ mariadb_tag }}"
 
 ##############################


### PR DESCRIPTION
The mariadb-server image is used as mariabackup image as well.

roles/mariadb/defaults/main.yml:mariabackup_image: "{{ docker_registry ~ '/' if
docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-mariadb-server"

Closes osism/issues#214

Signed-off-by: Christian Berendt <berendt@osism.tech>