### PR TITLE
Add new kolla-ansible variable

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -1144,6 +1144,7 @@ prometheus_elasticsearch_exporter_interval: "60s"
 prometheus_cmdline_extras:
 prometheus_ceph_mgr_exporter_endpoints: []
 prometheus_openstack_exporter_endpoint_type: "internal"
+prometheus_openstack_exporter_compute_api_version: "latest"
 prometheus_libvirt_exporter_interval: "60s"
 
 ############


### PR DESCRIPTION
The `prometheus_openstack_exporter_compute_api_version` variable was
introduced by [0] and backported into stable releases.

[0] https://review.opendev.org/c/openstack/kolla-ansible/+/828902

Fixes: osism/issues#256
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>