### PR TITLE
kolla: disable ceilometer-central healthcheck

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -84,3 +84,9 @@ es_java_opts: "-Dlog4j2.formatMsgNoLookups=true {% if es_heap_size %}-Xms{{ es_h
 
 # rolling upgrades
 glance_enable_rolling_upgrade: "yes"
+
+##########################################################
+# Bugfixes
+
+# NOTE: https://github.com/osism/issues/issues/231
+ceilometer_central_enable_healthchecks: "no"


### PR DESCRIPTION
The used check does not work in the ceilometer-central container. It probably depends
on the underlying operating system.

Closes osism/issues#231

Signed-off-by: Christian Berendt <berendt@osism.tech>