### PR TITLE
kolla: disable gnocchi-statsd healthcheck (#82)

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -96,3 +96,6 @@ glance_enable_rolling_upgrade: "yes"
 
 # NOTE: https://github.com/osism/issues/issues/231
 ceilometer_central_enable_healthchecks: "no"
+
+# NOTE: https://github.com/osism/issues/issues/288
+gnocchi_statsd_enable_healthchecks: "no"


### PR DESCRIPTION
The used check does not work in the gnocchi-statsd container.

Closes osism/issues#288

Signed-off-by: Christian Berendt <berendt@osism.tech>