### PR TITLE
kolla: add enable_prometheus_msteams: "no"

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -1116,6 +1116,7 @@ enable_prometheus_blackbox_exporter: "{{ enable_prometheus | bool }}"
 enable_prometheus_rabbitmq_exporter: "{{ enable_prometheus | bool and enable_rabbitmq | bool }}"
 enable_prometheus_libvirt_exporter: "{{ enable_prometheus | bool and enable_nova | bool and nova_compute_virt_type in ['kvm', 'qemu'] }}"
 enable_prometheus_etcd_integration: "{{ enable_prometheus | bool and enable_etcd | bool }}"
+enable_prometheus_msteams: "no"
 
 prometheus_alertmanager_user: "admin"
 prometheus_openstack_exporter_interval: "60s"


### PR DESCRIPTION
Required because of
https://github.com/openstack/kolla-ansible/commit/3d849c1efe1adee9862db4111794da84f86c2065

Signed-off-by: Christian Berendt <berendt@osism.tech>