### PR TITLE
Install python-is-python3 by default

### DIFF
--- a/all/099-generic.yml
+++ b/all/099-generic.yml
@@ -57,6 +57,7 @@ required_packages_default:
   - pciutils
   - pstack
   - pv
+  - python-is-python3
   - rsyslog
   - selinux-utils
   - socat


### PR DESCRIPTION
Closes osism/issues#367

Signed-off-by: Christian Berendt <berendt@osism.tech>