### PR TITLE
ceph: set configure_firewall = false

### DIFF
--- a/all/099-ceph.yml
+++ b/all/099-ceph.yml
@@ -3,11 +3,12 @@
 # generic
 
 ceph_share_directory: /share
+configure_firewall: false
 containerized_deployment: true
+dashboard_enabled: false
 fetch_directory: /share
 generate_fsid: false
 ntp_service_enabled: false
-dashboard_enabled: false
 
 # NOTE(berendt): We use an adapted Ceph image in which always the UID 64045 is used
 ceph_uid: 64045


### PR DESCRIPTION
The firewall tasks in ceph-infra are only available for SUSE and RedHat based distributions. Therefore, we can also deactivate and skip this by default.

Signed-off-by: Christian Berendt <berendt@osism.tech>