### PR TITLE
Add new kolla option for stable branches

### DIFF
--- a/all/001-kolla-defaults.yml
+++ b/all/001-kolla-defaults.yml
@@ -234,6 +234,8 @@ om_enable_rabbitmq_tls: "{{ rabbitmq_enable_tls | bool }}"
 # CA certificate bundle in containers using oslo.messaging with RabbitMQ TLS.
 om_rabbitmq_cacert: "{{ rabbitmq_cacert }}"
 
+om_enable_rabbitmq_high_availability: false
+
 ####################
 # Networking options
 ####################


### PR DESCRIPTION
In [0] om_enable_rabbitmq_high_availability was added as a new variable, add it to our kolla defaults.

[0] https://review.opendev.org/c/openstack/kolla-ansible/+/870494

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>