### PR TITLE
manager: remove cockpit_host

### DIFF
--- a/manager.yml
+++ b/manager.yml
@@ -1,6 +1,5 @@
 ---
 ara_server_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface|default(console_interface)]['ipv4']['address'] }}"
-cockpit_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface|default(console_interface)]['ipv4']['address'] }}"
 flower_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface|default(console_interface)]['ipv4']['address'] }}"
 netbox_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface|default(console_interface)]['ipv4']['address'] }}"
 vault_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface|default(console_interface)]['ipv4']['address'] }}"


### PR DESCRIPTION
The cockpit role was removed some time ago. This is a leftover.

Signed-off-by: Christian Berendt <berendt@osism.tech>