### PR TITLE
Registries: Change zuul registry to quay.io

### DIFF
--- a/all/000-registries.yml
+++ b/all/000-registries.yml
@@ -21,4 +21,4 @@ docker_registry_squid: index.docker.io
 docker_registry_traefik: index.docker.io
 docker_registry_vault: index.docker.io
 docker_registry_zookeeper: index.docker.io
-docker_registry_zuul: index.docker.io
+docker_registry_zuul: quay.io


### PR DESCRIPTION
Information from zuul-announce@lists.zuul-ci.org from 2023-04-27 22:14 CEST

depends osism/release#878

Signed-off-by: Tim Beermann <beermann@osism.tech>
