### PR TITLE
kolla: use redis as backend for osprofiler

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -84,6 +84,9 @@ enable_gnocchi_statsd: "no"
 # NOTE: https://github.com/osism/issues/issues/3
 fluentd_enable_watch_timer: "true"
 
+# osprofiler
+osprofiler_backend: "redis"
+
 # rolling upgrades
 glance_enable_rolling_upgrade: "yes"
 


### PR DESCRIPTION
This avoids conflicts with elasticsearch.