### PR TITLE
Drop enable_chrony from kolla defaults

### DIFF
--- a/all/099-kolla.yml
+++ b/all/099-kolla.yml
@@ -1,11 +1,5 @@
 ---
 ##########################################################
-# NOTE: The Chrony integrated in Kolla is not used. The
-#       osism.chrony role is used.
-
-enable_chrony: "no"
-
-##########################################################
 # Enable default set of services
 
 enable_common: "yes"


### PR DESCRIPTION
Kolla no longer deploys chrony, drop the variable from its defaults.